### PR TITLE
Fix jQuery not found error when jquery is loaded with defer

### DIFF
--- a/modules/comments/class-comments.php
+++ b/modules/comments/class-comments.php
@@ -72,10 +72,14 @@ class Comments {
 			'enabled' === \ZeroSpam\Core\Settings::get_settings( 'davidwalsh' )
 		) {
 			wp_enqueue_script( 'zerospam-davidwalsh' );
-			add_action( 'wp_footer', function() {
-				// .wpd_comm_form for the wpDiscuz plugin
-				echo '<script type="text/javascript">jQuery(".comment-form, #commentform, .wpd_comm_form").ZeroSpamDavidWalsh();</script>';
-			}, 999 );
+			add_action(
+				'wp_footer',
+				function (): void {
+					// .wpd_comm_form for the wpDiscuz plugin
+					echo '<script type="text/javascript">document.addEventListener("DOMContentLoaded", function() { jQuery(".comment-form, #commentform, .wpd_comm_form").ZeroSpamDavidWalsh(); });</script>';
+				},
+				999
+			);
 		}
 	}
 


### PR DESCRIPTION
### Description of the Change

### Changelog Entry
> Fixed - Bug fix

When loading jQuery with `defer`. jQuery will not be found. WordPress supports this natively now, but just does not apply it by default to jQuery.

I have seen other occurrences in the plugin `ZeroSpamDavidWalsh()` being added with and without a DOMContentLoaded wrapper. So they probably should all be changed to use the wrapper, but I am doing this PR just for this for now. Actually it might only he one in the WooCommerce class.

Also:
1. WP coding standards applied.
1. Based on the comment, this is actually just for "wpDiscuz plugin" so it does not need to be loaded at all for most users. Ideally, there should be a check if that plugin is active.
1. Is jQuery still needed on the frontend? Would love to see it gone. It's 2024 I consider it to outdated bloat.

### Credits
@nextgenthemes

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/Highfivery/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
